### PR TITLE
将JMEE源码根目录添加至模块查找路径中

### DIFF
--- a/enet/run/ee/runner.py
+++ b/enet/run/ee/runner.py
@@ -10,6 +10,8 @@ from tensorboardX import SummaryWriter
 from torchtext.data import Field
 from torchtext.vocab import Vectors
 
+sys.path.append(os.path.abspath(os.path.curdir))
+d
 from enet import consts
 from enet.corpus.Data import ACE2005Dataset, MultiTokenField, SparseField, EventField, EntityField
 from enet.models.ee import EDModel


### PR DESCRIPTION
经常在JMEE根目录直接运行此脚本，此优化可以避免找不到enet模块问题。